### PR TITLE
Add Tier 2 shaping regression against external harfrust corpus

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, release]
   pull_request:
-    branches: [main]
+    branches: [main, release]
   workflow_dispatch:
 
 env:
@@ -18,7 +18,7 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -26,7 +26,7 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2
 
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
           cache-dependency-glob: uv.lock
@@ -54,3 +54,40 @@ jobs:
 
       - name: Python tests
         run: uv run pytest
+
+  tier2:
+    # Tier 2: external regression against the full harfrust shaping corpus.
+    # Only runs on the release branch, where we care about version-drift signal.
+    if: github.ref == 'refs/heads/release' || github.base_ref == 'release'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check out harfrust at 0.5.2
+        uses: actions/checkout@v6
+        with:
+          repository: harfbuzz/harfrust
+          # Pinned to the 0.5.2 commit so the test corpus matches the hr-shape
+          # version declared in Cargo.toml. Bump this alongside the dep.
+          ref: efdae31
+          path: harfrust-external
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+
+      - name: Install Python deps
+        run: uv sync --locked
+
+      - name: Build extension
+        run: uv run maturin develop
+
+      - name: Tier 2 shaping regression
+        env:
+          HARFRUST_SOURCE: ${{ github.workspace }}/harfrust-external
+        run: uv run pytest -m external

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ reportMissingModuleSource = false
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+addopts = "-m 'not external'"
 markers = [
     "external: tests that require an external harfrust checkout via HARFRUST_SOURCE",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,6 +89,14 @@ def collect_tests_files():
 
 
 def _collect_external_cases(harfrust_source: str):
+    """Collect test cases from harfrust's generated .rs test files.
+
+    Note: We only parse .rs files in tests/shaping/, NOT the .tests files in
+    tests/custom/. The .tests files are source files for harfrust's test
+    generator (gen-shaping-tests.py) and may contain tests that are
+    intentionally excluded from the generated .rs files (e.g., macOS-only
+    tests, tests with known different expected values, etc.).
+    """
     cases = []
     harfrust_root = os.path.join(harfrust_source, "harfrust")
     shaping_dir = os.path.join(harfrust_root, "tests", "shaping")
@@ -96,11 +104,6 @@ def _collect_external_cases(harfrust_source: str):
         for f in sorted(os.listdir(shaping_dir)):
             if f.endswith(".rs") and f != "main.rs":
                 cases.extend(parse_rs_file(os.path.join(shaping_dir, f), harfrust_root))
-    custom_dir = os.path.join(harfrust_root, "tests", "custom")
-    if os.path.isdir(custom_dir):
-        for f in sorted(os.listdir(custom_dir)):
-            if f.endswith(".tests"):
-                cases.extend(parse_tests_file(os.path.join(custom_dir, f)))
     return cases
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,25 @@
 import os
+import re
 
 import pytest
 
 BUNDLED_DATA = os.path.join(os.path.dirname(__file__), "data")
 BUNDLED_FONTS = os.path.join(os.path.dirname(__file__), "fonts")
 HARFRUST_SOURCE = os.environ.get("HARFRUST_SOURCE")
+
+MIN_EXTERNAL_CASES = 5000
+
+_RS_TEST_RE = re.compile(
+    r"shape\(\s*"
+    r'"((?:\\.|[^"\\])*)"\s*,\s*'
+    r'"((?:\\.|[^"\\])*)"\s*,\s*'
+    r'"((?:\\.|[^"\\])*)"\s*,?\s*'
+    r"\)\s*,\s*"
+    r'"((?:\\.|[^"\\])*)"',
+    re.DOTALL,
+)
+_RS_U_ESC = re.compile(r"\\u\{([0-9A-Fa-f]+)\}")
+_RS_LINE_CONT = re.compile(r"\\\n\s*")
 
 
 def parse_tests_file(path):
@@ -32,6 +47,25 @@ def parse_tests_file(path):
     return cases
 
 
+def parse_rs_file(path, font_root):
+    """Extract test cases from a harfrust-generated tests/shaping/*.rs file.
+
+    Font paths inside the file are relative to the harfrust crate root
+    (e.g. "tests/fonts/in-house/X.ttf"); ``font_root`` is that root.
+    """
+    cases = []
+    with open(path) as f:
+        content = f.read()
+    for font_rel, text_lit, options, expected in _RS_TEST_RE.findall(content):
+        text = _RS_LINE_CONT.sub("", text_lit)
+        text = _RS_U_ESC.sub(lambda m: chr(int(m.group(1), 16)), text)
+        font_path = os.path.normpath(os.path.join(font_root, font_rel))
+        if not os.path.exists(font_path):
+            continue
+        cases.append((font_path, text, options, expected))
+    return cases
+
+
 def collect_tests_files():
     """Yield (case, is_external) pairs for every bundled and external test case."""
     cases = []
@@ -41,12 +75,32 @@ def collect_tests_files():
                 for case in parse_tests_file(os.path.join(BUNDLED_DATA, f)):
                     cases.append((case, False))
     if HARFRUST_SOURCE:
-        ext_tests = os.path.join(HARFRUST_SOURCE, "harfrust", "tests", "custom")
-        if os.path.isdir(ext_tests):
-            for f in sorted(os.listdir(ext_tests)):
-                if f.endswith(".tests"):
-                    for case in parse_tests_file(os.path.join(ext_tests, f)):
-                        cases.append((case, True))
+        external_cases = _collect_external_cases(HARFRUST_SOURCE)
+        if len(external_cases) < MIN_EXTERNAL_CASES:
+            raise RuntimeError(
+                f"HARFRUST_SOURCE is set to {HARFRUST_SOURCE!r} but only "
+                f"{len(external_cases)} Tier 2 cases were discovered "
+                f"(expected at least {MIN_EXTERNAL_CASES}). "
+                "Either the checkout is missing tests/shaping/*.rs or the parser "
+                "is out of sync with harfrust's test generator."
+            )
+        cases.extend((c, True) for c in external_cases)
+    return cases
+
+
+def _collect_external_cases(harfrust_source: str):
+    cases = []
+    harfrust_root = os.path.join(harfrust_source, "harfrust")
+    shaping_dir = os.path.join(harfrust_root, "tests", "shaping")
+    if os.path.isdir(shaping_dir):
+        for f in sorted(os.listdir(shaping_dir)):
+            if f.endswith(".rs") and f != "main.rs":
+                cases.extend(parse_rs_file(os.path.join(shaping_dir, f), harfrust_root))
+    custom_dir = os.path.join(harfrust_root, "tests", "custom")
+    if os.path.isdir(custom_dir):
+        for f in sorted(os.listdir(custom_dir)):
+            if f.endswith(".tests"):
+                cases.extend(parse_tests_file(os.path.join(custom_dir, f)))
     return cases
 
 


### PR DESCRIPTION
## Goal

  Get a high-confidence signal that `pyharfrust.shape` stays faithful to upstream harfrust output — not just on the handful of cases we bundle, but on the full shaping corpus harfrust itself uses to guard against regressions.  

  Bundled Tier 1 tests are fast and self-contained, but they cover a tiny slice of scripts and features. Every harfrust version bump is a chance for subtle output drift that our ~6 bundled cases would never catch. Tier 2 closes that gap. 

## Approach  

  **Opt-in, not always-on.** A harfrust checkout is a heavy dependency (fonts, generated test files, a specific commit pin), and the suite parametrizes into ~6 k cases. Making it the default would punish every local `pytest` run and every `main`-branch CI job for a signal that only matters at release time. 

  The mechanism:  

  - Set `HARFRUST_SOURCE=/path/to/harfrust` to enable.
  - Cases are marked `@pytest.mark.external` at collection time.
  - `pyproject.toml` default-denies via `addopts = "-m 'not external'"`, so Tier 2 only runs when the marker filter is explicitly overridden (`pytest -m external` or `-m ""`). 
  - A `MIN_EXTERNAL_CASES` floor ensures a silently-broken parser can't pass by collecting zero cases.  

  **Parse, don't re-run.** harfrust's corpus lives in generated `tests/shaping/*.rs` files containing literal `shape(...)` assertions. We extract the `(font, text, options, expected)` tuples with a targeted regex (handles `\u{XXXX}` escapes and line continuations), then compare against `pyharfrust.shape` output. We intentionally skip the `tests/custom/*.tests` source files — those are generator inputs that may contain stale expected values.

  **CI pinned to the shipped version.** Tier 2 runs on push/PR targeting `release`, against harfrust checked out at commit `efdae31` (the 0.5.2 tag, matching the `hr-shape` version in `Cargo.toml`). Bumping the dep means bumping the SHA in the same PR — corpus and shaper stay in lockstep. Main-branch CI is unchanged and still fast.

  ## Why regex over an AST 

  The `.rs` files are machine-generated with a rigid, uniform `shape("...", "...", "..."), "..."` shape. A full Rust parser (tree-sitter-rust, syn) would be overkill, add a heavy dep, and gain nothing on content this regular. If harfrust's generator format ever changes materially, the regex will fail loudly (via the min-case guard) rather than silently drift.  

  ## Out of scope 

  - Vendoring the harfrust corpus into this repo (too large, and would defeat the point of testing against upstream).
  - Automating the harfrust SHA bump alongside `hr-shape` — manual step, intentional coupling.