### PR TITLE
Update pre-commit configuration and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,7 @@ jobs:
           repository: harfbuzz/harfrust
           # Pinned to the 0.5.2 commit so the test corpus matches the hr-shape
           # version declared in Cargo.toml. Bump this alongside the dep.
-          ref: efdae31
+          ref: efdae3142ab76a2f1524d72cff9e3dfdc5afd7ca
           path: harfrust-external
 
       - uses: dtolnay/rust-toolchain@stable

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     - id: check-added-large-files
     - id: check-merge-conflict
     - id: no-commit-to-branch
-      args: [--branch, main]
+      args: [--branch, main, --branch, release]
 
 - repo: https://github.com/astral-sh/uv-pre-commit
   rev: 0.11.3


### PR DESCRIPTION
- Modified `.pre-commit-config.yaml` to enforce checks on both `main` and `release` branches.
- Updated `.github/workflows/ci.yml` to pin the `harfrust` repository reference to a specific commit for consistency in CI testing.