### PR TITLE
Upgrade GitHub Actions for artifact handling and macOS runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
           manylinux: auto
           args: --release --out dist -i python3.11 -i python3.12 -i python3.13
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: wheels-linux-${{ matrix.target }}
           path: dist
@@ -56,7 +56,7 @@ jobs:
         python-version: ['3.11', '3.12', '3.13']
         include:
           - target: x86_64
-            runner: macos-13
+            runner: macos-15-intel
           - target: aarch64
             runner: macos-14
     runs-on: ${{ matrix.runner }}
@@ -72,7 +72,7 @@ jobs:
           target: ${{ matrix.target }}
           args: --release --out dist -i python${{ matrix.python-version }}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: wheels-macos-${{ matrix.target }}-py${{ matrix.python-version }}
           path: dist
@@ -98,7 +98,7 @@ jobs:
           target: ${{ matrix.target }}
           args: --release --out dist
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: wheels-windows-${{ matrix.target }}-py${{ matrix.python-version }}
           path: dist
@@ -114,7 +114,7 @@ jobs:
           command: sdist
           args: --out dist
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: sdist
           path: dist
@@ -132,7 +132,7 @@ jobs:
       # at https://pypi.org/manage/account/publishing/ before tagging a release.
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           path: dist
           merge-multiple: true


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow in `.github/workflows/release.yml` to use newer versions of actions and updates the macOS runner for one of the build targets. These changes help keep our CI/CD pipeline up-to-date and ensure compatibility with the latest environments.
